### PR TITLE
PortAudio: Limit high sample rate streams to 1 second output threshold

### DIFF
--- a/src/squeezeplay/src/audio/decode/decode_alsa_backend.c
+++ b/src/squeezeplay/src/audio/decode/decode_alsa_backend.c
@@ -291,6 +291,8 @@ static void playback_callback(struct decode_alsa *state,
 
 	/* Should we start the audio now based on having enough decoded data?
 	   - override output_thresh for 176/192k and wait for 1 sec of data before starting */
+	/* Supplementary note: this 1 sec  override is required for 352/384k to prevent stalls.
+	   Refer note against 'DECODE_FIFO_SIZE' in 'decode_priv.h'. */
 	if (decode_audio->state & DECODE_STATE_AUTOSTART
 			&& decode_frames > (output_frames * (3 + state->period_count))
 			&& decode_frames > (state->pcm_sample_rate <= 96000 ? (decode_audio->output_threshold * state->pcm_sample_rate / 10) :

--- a/src/squeezeplay/src/audio/decode/decode_priv.h
+++ b/src/squeezeplay/src/audio/decode/decode_priv.h
@@ -210,6 +210,15 @@ extern bool_t decode_first_buffer;
 
 
 /* The fifo used to store decoded samples */
+/* '10 * 2 * 44100 * sizeof(sample_t)' equates to:
+	10 seconds of a 44,100 Hz stream,
+	2.29 seconds of a 192,000 Hz stream,
+	1.14 seconds of a 384,000 Hz stream.
+    SqueezePlay will stall if the requested output threshold approaches
+    these limits. For example, LMS sets an output threshold of 2 seconds
+    for a 'high sample rate ( >= 88200 )' flac stream.
+    Refer 'decode_alsa_backend.c' and 'decode_portaudio.c' for mitigation.
+*/
 #define DECODE_FIFO_SIZE (10 * 2 * 44100 * sizeof(sample_t)) 
 extern u8_t *decode_fifo_buf;
 


### PR DESCRIPTION
SqueezePlay on macOS will stall when playing a flac file with 352 kHz sample rate.

The cause is insufficient available audio output buffer capacity: LMS sets an output threshold of 2 seconds for such files, and the existing output buffer will only accommodate about 1.1 seconds.

SqueezePlay on macOS uses PortAudio. This proposed change replicates a change already taken up in the Alsa audio backend, which limits the output threshold to 1 second. It has been effective on the very few 352/384 kHz test files that I have, and has the advantage of applying a consistent approach to both backends.

Flac files with sample rates greater than 384 kHz (e.g. 768 kHz) would, more than likely, continue to stall with the existing output buffer size, or with the 1 second threshold. That may require consideration should SqueezePlay ever be called upon to render them.

I have only been able to test on a macOS X86_64 platform (Mojave, 10.14.6). Built against MacOSX10.11.sdk which I found from somewhere !

During the build I observed that `fdk-aac-2.0.1` has no configure script, which required a run of `autogen.h` for the build to succeed.

This is a follow up to our discussion on the LMS forum:

https://forums.slimdevices.com/showthread.php?113234-LMS-7-9-4-and-8-0-x-no-longer-play-PCM-352-files-(DXD)&p=995522&viewfull=1#post995522
