### PR TITLE
[Untested] double the watchdog enforced restart interval

### DIFF
--- a/src/squeezeplay/src/ui/jive_framework.c
+++ b/src/squeezeplay/src/ui/jive_framework.c
@@ -1055,7 +1055,7 @@ int jiveL_event(lua_State *L) {
 
 
 int jiveL_get_ticks(lua_State *L) {
-	lua_pushinteger(L, jive_jiffies());
+	lua_pushnumber(L, (double)jive_jiffies());
 	return 1;
 }
 


### PR DESCRIPTION
lua_pushinteger() treats the value of jive_jiffies() as a signed
integer, causing critical MAX_VAL to be reached after 24 days rather
than the expected 49 days. By casting the result as a double and
calling lua_pushnumber() instead we eliminate the sign change and
thereby double the watchdog enforced restart interval.

Signed-off-by: gordonb3 <gordon@bosvangennip.nl>