### PR TITLE
remove -force_cpusubtype_ALL gcc flag from squeezeplay/Makefile.*

### DIFF
--- a/src/squeezeplay/Makefile.am
+++ b/src/squeezeplay/Makefile.am
@@ -53,7 +53,6 @@ OSX_STATIC_LIBS = `$(SDL_CONFIG) --static-libs` \
 
 SqueezePlay: $(jive_OBJECTS) $(jive_DEPENDENCIES)
 	$(CC) $(LDFLAGS) \
-	-force_cpusubtype_ALL \
 	-framework CoreAudio \
 	-o $(JIVE_STATIC_PROGRAM) $(jive_OBJECTS)   \
 	$(OSX_STATIC_LIBS) \

--- a/src/squeezeplay/Makefile.in
+++ b/src/squeezeplay/Makefile.in
@@ -1266,7 +1266,6 @@ install-data-local: jive-static-install
 
 SqueezePlay: $(jive_OBJECTS) $(jive_DEPENDENCIES)
 	$(CC) $(LDFLAGS) \
-	-force_cpusubtype_ALL \
 	-framework CoreAudio \
 	-o $(JIVE_STATIC_PROGRAM) $(jive_OBJECTS)   \
 	$(OSX_STATIC_LIBS) \


### PR DESCRIPTION
It appears gcc flag `-force_cpusubtype_ALL` has disappeared from Apple Clang 15.0.0.  After a cursory look at the v15 [release notes](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html) and source, I could not see any obvious references to it, so perhaps it is an Apple thing.

The result is failed linkage.
```
creating libui.la
(cd .libs && rm -f libui.la && ln -s ../libui.la libui.la)
gcc -arch arm64 -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -mmacosx-version-min=11.0 -L/redacted/build/osx/lib -L/usr/lib \
	-force_cpusubtype_ALL \
	-framework CoreAudio \
	-o SqueezePlay jive.o jive_debug.o log.o   \
	`/redacted/build/osx/bin/sdl-config --static-libs` /redacted/build/osx/lib/liblua.a /redacted/build/osx/lib/libtolua++.a /redacted/build/osx/lib/libogg.a /redacted/build/osx/lib/libFLAC.a /redacted/build/osx/lib/libfreetype.a /redacted/build/osx/lib/libmad.a /redacted/build/osx/lib/libvorbisidec.a /redacted/build/osx/lib/libportaudio.a /redacted/build/osx/lib/libSDL.a /redacted/build/osx/lib/libSDL_gfx.a /redacted/build/osx/lib/libSDL_image.a /redacted/build/osx/lib/libSDL_ttf.a /redacted/build/osx/lib/libSDLmain.a /redacted/build/osx/lib/libpng.a /redacted/build/osx/lib/libjpeg.a /redacted/build/osx/lib/libfdk-aac.a ./.libs/libaudio.a ./.libs/libnet.a ./.libs/libui.a ./.libs/libdecode.a \
	-lz -lresolv
ld: unknown options: -force_cpusubtype_ALL
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [SqueezePlay] Error 1
make: *** [squeezeplay_dmg] Error 2
```

This flag is ppc64 related.  Although it does show up in SDL-1.2.15, it is in `$EXTRA_CFLAGS` which its Makefile never uses, so it is harmless in that directory.

Here are two machines, both running macOS Version 13.6 (22G120) but with different XCode versions.  Compilation works on CLang 14.0.3 but not 15.0.0.

```
x86_64 % gcc --version
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: x86_64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

x86_64 % /usr/bin/xcodebuild -version
Xcode 14.3.1
Build version 14E300c
```

```
M1 % gcc --version                                                                                                                       
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

M1 % /usr/bin/xcodebuild -version
Xcode 15.0
Build version 15A240d
```