### PR TITLE
macOS hotplug support

### DIFF
--- a/src/Makefile.osx-M1
+++ b/src/Makefile.osx-M1
@@ -29,6 +29,8 @@ export BUILD_TOP=$(BASE_DIR)build/osx
 
 export PREFIX=${BUILD_TOP}
 
+export JIVE_LDFLAGS=-Wl,-framework,CoreAudio
+
 ARCHFLAGS=-arch $(ARCH)
 export CFLAGS=$(ARCHFLAGS) -I${PREFIX}/include -I${PREFIX}/include/SDL -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -mmacosx-version-min=11.0
 export CXXFLAGS=$(ARCHFLAGS) -I${PREFIX}/include -I${PREFIX}/include/SDL -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -mmacosx-version-min=11.0

--- a/src/Makefile.osx-i386
+++ b/src/Makefile.osx-i386
@@ -25,6 +25,8 @@ export BUILD_TOP=$(BASE_DIR)build/osx
 
 export PREFIX=${BUILD_TOP}
 
+export JIVE_LDFLAGS=-Wl,-framework,CoreAudio
+
 ARCHFLAGS=-arch $(ARCH)
 export CFLAGS=$(ARCHFLAGS) -I${PREFIX}/include -I${PREFIX}/include/SDL -isysroot /Developer/SDKs/MacOSX10.6.sdk/ -mmacosx-version-min=10.4
 export LDFLAGS=$(ARCHFLAGS) -Wl,-syslibroot,/Developer/SDKs/MacOSX10.6.sdk/ -mmacosx-version-min=10.4 -L${PREFIX}/lib -L/usr/lib

--- a/src/Makefile.osx-ppc
+++ b/src/Makefile.osx-ppc
@@ -27,6 +27,8 @@ export BUILD_TOP=$(BASE_DIR)build/osx
 
 export PREFIX=${BUILD_TOP}
 
+export JIVE_LDFLAGS=-Wl,-framework,CoreAudio
+
 ARCHFLAGS=-arch $(ARCH)
 export CFLAGS=-mcpu=G3 $(ARCHFLAGS) -I${PREFIX}/include -I${PREFIX}/include/SDL -isysroot /Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.3
 export LDFLAGS=$(ARCHFLAGS) -Wl,-syslibroot,/Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.3 -L${PREFIX}/lib -L/usr/lib

--- a/src/Makefile.osx-x86_64
+++ b/src/Makefile.osx-x86_64
@@ -27,6 +27,8 @@ export BUILD_TOP=$(BASE_DIR)build/osx
 
 export PREFIX=${BUILD_TOP}
 
+export JIVE_LDFLAGS=-Wl,-framework,CoreAudio
+
 ARCHFLAGS=-arch $(ARCH)
 export CFLAGS=$(ARCHFLAGS) -I${PREFIX}/include -I${PREFIX}/include/SDL -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -mmacosx-version-min=10.7
 export CXXFLAGS=$(ARCHFLAGS) -I${PREFIX}/include -I${PREFIX}/include/SDL -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -mmacosx-version-min=10.7

--- a/src/squeezeplay/Makefile.am
+++ b/src/squeezeplay/Makefile.am
@@ -244,7 +244,7 @@ jive_SOURCES = \
 	src/jive_debug.c \
 	src/log.c
 
-jive_LDADD = libui.la libdecode.la libnet.la -lfdk-aac -llua ${SPPRIVATE_LIB}
+jive_LDADD = libui.la libdecode.la libnet.la -lfdk-aac -llua ${JIVE_LDFLAGS} ${SPPRIVATE_LIB}
 
 jive_alsa_SOURCES = \
 	src/audio/decode/decode_alsa_backend.c

--- a/src/squeezeplay/Makefile.in
+++ b/src/squeezeplay/Makefile.in
@@ -356,7 +356,7 @@ jive_SOURCES = \
 	src/jive_debug.c \
 	src/log.c
 
-jive_LDADD = libui.la libdecode.la libnet.la -lfdk-aac -llua ${SPPRIVATE_LIB}
+jive_LDADD = libui.la libdecode.la libnet.la -lfdk-aac -llua ${JIVE_LDFLAGS} ${SPPRIVATE_LIB}
 jive_alsa_SOURCES = \
 	src/audio/decode/decode_alsa_backend.c
 


### PR DESCRIPTION
macOS hotplug support

Handle runtime changes of default audio output device like pairing Bluetooth headphones, plugging/unplugging 3.5mm jack, changing Sound Output in Audio MIDI Setup, etc.

Tested on macOS 13.6 M1, 10.13.6 x86_64, 10.12.6 x86_64

Known issues:

 * There can be a race condition after plugging in the 3.5mm jack but before the External Headphones device is available.  Retrying the plug usually works.
 * ZoomAudioDevice does not play nicely.  It can be removed via CLI if you are not sharing programmatic audio.