### PR TITLE
double click Now Playing applet to cycle skins

### DIFF
--- a/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
+++ b/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
@@ -126,6 +126,7 @@ function init(self)
 	jnt:subscribe(self)
 	self.player = false
 	self.lastVolumeSliderAdjustT = 0
+	self.lastMouseClickT = 0
 	self.cumulativeScrollTicks = 0
 
 	local settings      = self:getSettings()
@@ -1324,6 +1325,14 @@ end
 function toggleNPScreenStyle(self)
 
 	log:debug('change window style')
+
+	-- double click in milliseconds
+	local now = Framework:getTicks()
+	if now - self.lastMouseClickT > 500 then
+		self.lastMouseClickT = now
+		return
+	end
+
 	local enabledNPScreenStyles = {}
 	for i, v in ipairs(self.nowPlayingScreenStyles) do
 		if v.enabled then

--- a/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
+++ b/src/squeezeplay/share/applets/NowPlaying/NowPlayingApplet.lua
@@ -130,8 +130,11 @@ function init(self)
 	self.cumulativeScrollTicks = 0
 
 	local settings      = self:getSettings()
+	local defaults      = self:getDefaultSettings()
 	self.scrollText     = settings["scrollText"]
 	self.scrollTextOnce = settings["scrollTextOnce"]
+	self.doubleClickMode = settings["doubleClickMode"] or defaults["doubleClickMode"]
+	self.doubleClickInterval = settings["doubleClickInterval"] or defaults["doubleClickInterval"]
 
 end
 
@@ -1328,7 +1331,7 @@ function toggleNPScreenStyle(self)
 
 	-- double click in milliseconds
 	local now = Framework:getTicks()
-	if now - self.lastMouseClickT > 500 then
+	if self.doubleClickMode and now - self.lastMouseClickT > self.doubleClickInterval then
 		self.lastMouseClickT = now
 		return
 	end
@@ -2000,4 +2003,66 @@ function free(self)
 	return true
 end
 
+function setDoubleClickMode(self, doubleClickMode)
+	self.doubleClickMode = doubleClickMode
+	local settings = self:getSettings()
+	settings.doubleClickMode = doubleClickMode
+	self:storeSettings()
+end
 
+function clickModeSettingsShow(self)
+	local window = Window("text_list", self:string('NOW_PLAYING_CLICK_MODE'))
+
+	local group = RadioGroup()
+
+	local menu = SimpleMenu("menu", {
+			{
+				text = self:string('NOW_PLAYING_CLICK_MODE_SINGLE'),
+				style = 'item_choice',
+				check = RadioButton("radio", group, function(event) self:setDoubleClickMode(false) end, not self.doubleClickMode)
+			},
+			{
+				text = self:string('NOW_PLAYING_CLICK_MODE_DOUBLE'),
+				style = 'item_choice',
+				check = RadioButton("radio", group, function(event) self:setDoubleClickMode(true) end, self.doubleClickMode)
+			},
+		})
+
+	window:addWidget(menu)
+	menu:setHeaderWidget(Textarea("help_text", self:string('NOW_PLAYING_CLICK_MODE_HELP')))
+	window:show()
+end
+
+function setDoubleClickInterval(self, interval)
+	self.doubleClickInterval = interval
+	local settings = self:getSettings()
+	settings.doubleClickInterval = interval
+	self:storeSettings()
+end
+
+function clickIntervalSettingsShow(self)
+	local window = Window("text_list", self:string('NOW_PLAYING_CLICK_INTERVAL'))
+
+	local group = RadioGroup()
+
+	local menu = SimpleMenu("menu", {
+			{
+				text = self:string('NOW_PLAYING_CLICK_INTERVAL_DEFAULT'),
+				style = 'item_choice',
+				check = RadioButton("radio", group, function(event) self:setDoubleClickInterval(500) end, self.doubleClickInterval == 500)
+			},
+			{
+				text = self:string('NOW_PLAYING_CLICK_INTERVAL_1000MS'),
+				style = 'item_choice',
+				check = RadioButton("radio", group, function(event) self:setDoubleClickInterval(1000) end, self.doubleClickInterval == 1000)
+			},
+			{
+				text = self:string('NOW_PLAYING_CLICK_INTERVAL_2000MS'),
+				style = 'item_choice',
+				check = RadioButton("radio", group, function(event) self:setDoubleClickInterval(2000) end, self.doubleClickInterval == 2000)
+			},
+		})
+
+	window:addWidget(menu)
+	window:show()
+end

--- a/src/squeezeplay/share/applets/NowPlaying/NowPlayingMeta.lua
+++ b/src/squeezeplay/share/applets/NowPlaying/NowPlayingMeta.lua
@@ -19,6 +19,8 @@ function defaultSettings(self)
 		scrollText = true,
 		scrollTextOnce = false,
 		views = {},
+		doubleClickMode = false,
+		doubleClickInterval = 500,
 	}
 end
 
@@ -31,7 +33,8 @@ function registerApplet(self)
 			'SCREENSAVER_SCROLLMODE', 
 			function(applet, ...) 
 				applet:scrollSettingsShow(...) 
-			end
+			end,
+			2
 		)
 	)
 	jiveMain:addItem(
@@ -41,7 +44,30 @@ function registerApplet(self)
 			'NOW_PLAYING_VIEWS', 
 			function(applet, ...) 
 				applet:npviewsSettingsShow(...) 
-			end
+			end,
+			1
+		)
+	)
+	jiveMain:addItem(
+		self:menuItem(
+			'appletNowPlayingClickMode',
+			'screenSettingsNowPlaying',
+			'NOW_PLAYING_CLICK_MODE',
+			function(applet, ...)
+				applet:clickModeSettingsShow(...)
+			end,
+			3
+		)
+	)
+	jiveMain:addItem(
+		self:menuItem(
+			'appletNowPlayingClickInterval',
+			'screenSettingsNowPlaying',
+			'NOW_PLAYING_CLICK_INTERVAL',
+			function(applet, ...)
+				applet:clickIntervalSettingsShow(...)
+			end,
+			4
 		)
 	)
 	self:registerService('goNowPlaying')

--- a/src/squeezeplay/share/applets/NowPlaying/strings.txt
+++ b/src/squeezeplay/share/applets/NowPlaying/strings.txt
@@ -227,3 +227,26 @@ NOW_PLAYING_VIEWS_HELP
 	RU	Существует несколько видов экрана воспроизведения, между которыми можно переключаться. Здесь можно выбрать несколько видов для этого плеера.
 	SV	Skärmbilden Nu spelas har några olika fönsterkonfigurationer eller vyer som du kan växla mellan. Här väljer du vilken vy du vill ha i den här spelaren.
 
+NOW_PLAYING_CLICK_MODE
+	EN	Click Mode
+
+NOW_PLAYING_CLICK_MODE_HELP
+	EN	Number of clicks to rotate views
+
+NOW_PLAYING_CLICK_MODE_SINGLE
+	EN	Single Click
+
+NOW_PLAYING_CLICK_MODE_DOUBLE
+	EN	Double Click
+
+NOW_PLAYING_CLICK_INTERVAL
+	EN	Double Click Time
+
+NOW_PLAYING_CLICK_INTERVAL_DEFAULT
+	EN	500 ms
+
+NOW_PLAYING_CLICK_INTERVAL_1000MS
+	EN	1 s
+
+NOW_PLAYING_CLICK_INTERVAL_2000MS
+	EN	2 s


### PR DESCRIPTION
This patch fixes one of my biggest annoyances with Squeezeplay: a single click within the Now Playing applet cycles the visualizer skins.  Squeezeplay’s user interface behavior is unique in that clicking on the main “page” of the app completely changes the way the app looks.  This can be very frustrating when all you want to do is click on the app to acquire input focus.  If the app is already in the foreground, the skin changes when you click on it, and now you have to cycle through the skins to get it back to what you want it to be.  This forces you to treat Squeezeplay gingerly by having to remember to click on the title bar carefully or else you have to cycle through the skins.

This patch changes the Now Playing applet behavior so that a double click is required to change the skin.  This allows you to safely get input focus by clicking on the app while retaining the ability to change the Now Playing skin if you really want to.

It’s true you can work around this issue by going into Settings → Screen → Now Playing → Now Playing Views and deselecting all but the one skin you care about, but that’s a lot of clicking, and most people won’t know that they have to do that.  It also limits what skins are available, so if you ever wanted to briefly look at another visualizer, you would have to navigate through all those settings screens again.

Tested on macOS 10.13.6 and 13.6.