### PR TITLE
macOS memory leak fix

### DIFF
--- a/src/SDL-1.2.15/src/video/quartz/SDL_QuartzVideo.m
+++ b/src/SDL-1.2.15/src/video/quartz/SDL_QuartzVideo.m
@@ -1051,7 +1051,7 @@ static SDL_Surface* QZ_SetVideoWindowed (_THIS, SDL_Surface *current, int width,
         }
 
         [ qz_window setDelegate:
-            [ [ SDL_QuartzWindowDelegate alloc ] init ] ];
+            (id<NSWindowDelegate>)[ [ SDL_QuartzWindowDelegate alloc ] init ] ];
         [ qz_window setContentView: [ [ [ SDL_QuartzView alloc ] init ] autorelease ] ];
     }
     /* We already have a window, just change its size */

--- a/src/SDL-1.2.15/src/video/quartz/SDL_QuartzVideo.m
+++ b/src/SDL-1.2.15/src/video/quartz/SDL_QuartzVideo.m
@@ -1563,9 +1563,7 @@ static void QZ_UpdateRects (_THIS, int numRects, SDL_Rect *rects)
         /* Do nothing if miniaturized */
     }
     else {
-	[ window_view setNeedsDisplay:YES ];
-	[ [ qz_window contentView ] setNeedsDisplay:YES ];
-	[ qz_window displayIfNeeded ];
+	dispatch_async(dispatch_get_main_queue(), ^(void){ [ window_view setNeedsDisplay:YES ]; [ [ qz_window contentView ] setNeedsDisplay:YES ]; [ qz_window displayIfNeeded ]; });
     }
 }
 

--- a/src/SDL-1.2.15/src/video/quartz/SDL_QuartzVideo.m
+++ b/src/SDL-1.2.15/src/video/quartz/SDL_QuartzVideo.m
@@ -940,9 +940,7 @@ static SDL_Surface* QZ_SetVideoFullScreen (_THIS, SDL_Surface *current, int widt
     /* Set app state, hide cursor if necessary, ... */
     QZ_DoActivate(this);
 
-    [ window_view setNeedsDisplay:YES ];
-  	[ [ qz_window contentView ] setNeedsDisplay:YES ];
-  	[ qz_window displayIfNeeded ];
+	dispatch_async(dispatch_get_main_queue(), ^(void){ [ window_view setNeedsDisplay:YES ]; [ [ qz_window contentView ] setNeedsDisplay:YES ]; [ qz_window displayIfNeeded ]; });
     
     return current;
 
@@ -1120,9 +1118,7 @@ static SDL_Surface* QZ_SetVideoWindowed (_THIS, SDL_Surface *current, int width,
     /* Save flags to ensure correct teardown */
     mode_flags = current->flags;
     
-    [ window_view setNeedsDisplay:YES ];
-   	[ [ qz_window contentView ] setNeedsDisplay:YES ];
-   	[ qz_window displayIfNeeded ];
+	dispatch_async(dispatch_get_main_queue(), ^(void){ [ window_view setNeedsDisplay:YES ]; [ [ qz_window contentView ] setNeedsDisplay:YES ]; [ qz_window displayIfNeeded ]; });
     
     /* Fade in again (asynchronously) if we came from a fullscreen mode and faded to black */
     if (fade_token != kCGDisplayFadeReservationInvalidToken) {

--- a/src/SDL-1.2.15/src/video/quartz/SDL_QuartzWindow.m
+++ b/src/SDL-1.2.15/src/video/quartz/SDL_QuartzWindow.m
@@ -31,7 +31,7 @@
     it doesn't seem to matter what value it has.
 */
 static void QZ_SetPortAlphaOpaque () {
-    
+    return; // no longer needed
     SDL_Surface *surface = current_video->screen;
     int bpp;
     

--- a/src/squeezeplay/src/ui/jive_framework.c
+++ b/src/squeezeplay/src/ui/jive_framework.c
@@ -328,6 +328,7 @@ static int jiveL_initSDL(lua_State *L) {
 		jive_surface_blit(splash, srf, (screen_w - splash_w) > 0 ?((screen_w - splash_w) / 2):0, (screen_w - splash_w) > 0 ?((screen_w - splash_w) / 2):0);
 		jive_surface_flip(srf);
 		LOG_INFO(log_ui_draw, "Splash %s %dx%d Screen %dx%d", splashfile,splash_w,splash_h,screen_w,screen_h);
+		SDL_PumpEvents(); // pump event queue to update screen
 	}
 
 	lua_getfield(L, 1, "screen");

--- a/src/squeezeplay/src/ui/jive_surface.c
+++ b/src/squeezeplay/src/ui/jive_surface.c
@@ -95,6 +95,7 @@ static int _new_image(const char *path) {
 			/* should probably be a fatal error */
 			return 0;
 		}
+		memset(images, 0, image_pool_size * sizeof(images[0]));
 	}
 
 	// Zero is invaild! so start at one... yes we waste an entry... but there is alot of code that relies on this


### PR DESCRIPTION
This patch fixes a memory leak in macOS Squeezeplay induced by redrawing the rectangles of scrolling text in the Now Playing applet.  To reproduce the symptom, set the screensaver to Now Playing with album and track names whose lengths exceed the width of the screen and require scrolling.  Let Squeezeplay run for awhile, and you will see the memory usage creep up in Activity Monitor every time the text scrolls.  Left running for too long, the app will eventually consume gigabytes of virtual memory. 

This doesn’t happen with the Linux build, which helped me narrow it down to Quartz.  The root cause is outlined in this [stackoverflow article](https://stackoverflow.com/questions/42270636/macos-memory-consumption-caused-by-setneedsdisplayinrect).  The leak is avoided by forcing redraws to happen in the main thread. 

You can examine the memory usage with the following steps.

```
# first, add -g to CFLAGS in the Makefiles for Squeezeplay and SDL-1.2 in order to get line number references
make

# start Squeezeplay with memory trace logging, and let it run for awhile
MallocStackLogging=YES  ../build/osx/SqueezePlay.app/Contents/MacOS/SqueezePlay

# extract a memory graph from the running process with the macOS leaks tool
leaks <pid> -outputGraph foo.memgraph

# generate a summary report from the memory graph
malloc_history foo.memgraph -allBySize > /tmp/foo

# pick a line with a lot of repeated mallocs, and generate a trace from it
head -55 /tmp/foo | tail -1 | perl -ne '@lines = split(/[|]/); print join("\n", @lines);'
```

This will output a trace like the following.

```
[...]
 0x10feb7c87 (com.logitech.squeezeplay) -[SDLMain applicationDidFinishLaunching:]  SDLMain.m:283
 0x10feb46c7 (com.logitech.squeezeplay) SDL_main  jive.c:562
 0x10ff0e26e (com.logitech.squeezeplay) lua_cpcall
 0x10ff1537a (com.logitech.squeezeplay) luaD_pcall
 0x10ff13e15 (com.logitech.squeezeplay) luaD_rawrunprotected
 0x10ff0e34f (com.logitech.squeezeplay) f_Ccall
 0x10ff14f39 (com.logitech.squeezeplay) luaD_call
 0x10ff14764 (com.logitech.squeezeplay) luaD_precall
 0x10feb4863 (com.logitech.squeezeplay) pmain  jive.c:533
 0x10feb527a (com.logitech.squeezeplay) handle_script  jive.c:433
 0x10feb5410 (com.logitech.squeezeplay) docall  jive.c:396
 0x10ff0e18a (com.logitech.squeezeplay) lua_pcall
 0x10ff1537a (com.logitech.squeezeplay) luaD_pcall
 0x10ff13e15 (com.logitech.squeezeplay) luaD_rawrunprotected
 0x10ff0e1ff (com.logitech.squeezeplay) f_call
 0x10ff14f39 (com.logitech.squeezeplay) luaD_call
 0x10ff14764 (com.logitech.squeezeplay) luaD_precall
 0x10ff38b35 (com.logitech.squeezeplay) ll_require
 0x10ff0e095 (com.logitech.squeezeplay) lua_call
 0x10ff14f50 (com.logitech.squeezeplay) luaD_call
 0x10ff2877d (com.logitech.squeezeplay) luaV_execute
 0x10ff14764 (com.logitech.squeezeplay) luaD_precall
 0x11014fc17 (com.logitech.squeezeplay) jiveL_update_screen  jive_framework.c:0
 0x11015d339 (com.logitech.squeezeplay) jive_surface_flip  jive_surface.c:1270
 0x10fef6ff9 (com.logitech.squeezeplay) SDL_Flip  SDL_video.c:1153
 0x10fef69a6 (com.logitech.squeezeplay) SDL_UpdateRect  SDL_video.c:1036
 0x10fef6d66 (com.logitech.squeezeplay) SDL_UpdateRects  SDL_video.c:1099
 0x10ff021cb (com.logitech.squeezeplay) QZ_UpdateRects  SDL_QuartzVideo.m:1567
 0x7fff29b7e101 (com.apple.AppKit) -[NSView setNeedsDisplay:]
 0x7fff29b7e244 (com.apple.AppKit) -[NSView setNeedsDisplayInRect:]
 0x7fff29b7e4cc (com.apple.AppKit) NSViewSetNeedsDisplayInRect
 0x7fff29c1d763 (com.apple.AppKit) -[NSWindow _setNeedsDisplayInRect:]
 0x7fff29c1db42 (com.apple.AppKit) -[NSDisplayCycleObserver setNeedsDisplay:]
 0x7fff29bb9de7 (com.apple.AppKit) +[NSDisplayCycle currentDisplayCycle]
 0x7fff29bb9fd9 (com.apple.AppKit) -[NSDisplayCycle init]
 0x7fff2e6e98ce (com.apple.Foundation) NSAllocateObject
 0x7fff5393acea (libobjc.A.dylib) class_createInstance
 0x7fff54711612 (libsystem_malloc.dylib) calloc
 0x7fff54710d24 (libsystem_malloc.dylib) malloc_zone_calloc
```

Tested on 10.13.6 x86_64 and 13.6 arm64