### PR TITLE
use math.h instead of fp.h in libpng on macOS

### DIFF
--- a/src/libpng-1.2.59/pngconf.h
+++ b/src/libpng-1.2.59/pngconf.h
@@ -425,14 +425,6 @@
 
 #ifdef PNG_FLOATING_POINT_SUPPORTED
 #  ifdef MACOS
-     /* We need to check that <math.h> hasn't already been included earlier
-      * as it seems it doesn't agree with <fp.h>, yet we should really use
-      * <fp.h> if possible.
-      */
-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
-#      include <fp.h>
-#    endif
-#  else
 #    include <math.h>
 #  endif
 #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)


### PR DESCRIPTION
fp.h has been deprecated for some time and was finally removed in macOS Sequoia 15.4.1.  This causes libpng-1.2.59 compilation to fail:

```
In file included from png.c:17:
In file included from ./png.h:321:
./pngconf.h:433:16: fatal error: 'fp.h' file not found
  433 | #      include <fp.h>
      |                ^~~~~~
1 error generated.
```

This patch uses math.h unconditionally.

Tested on:
* macOS 15.4.1
* Mac OS X 10.13.6