### PR TITLE
macOS memory leak fix in SDL_QuartzEvents.m

### DIFF
--- a/src/SDL-1.2.15/src/video/quartz/SDL_QuartzEvents.m
+++ b/src/SDL-1.2.15/src/video/quartz/SDL_QuartzEvents.m
@@ -807,7 +807,6 @@ void QZ_PumpEvents (_THIS)
     NSDate *distantPast;
     NSEvent *event;
     NSRect winRect;
-    NSAutoreleasePool *pool;
 
     if (!SDL_VideoSurface)
         return;  /* don't do anything if there's no screen surface. */
@@ -823,7 +822,6 @@ void QZ_PumpEvents (_THIS)
         }
     }
 
-    pool = [ [ NSAutoreleasePool alloc ] init ];
     distantPast = [ NSDate distantPast ];
 
     winRect = NSMakeRect (0, 0, SDL_VideoSurface->w, SDL_VideoSurface->h);
@@ -833,6 +831,7 @@ void QZ_PumpEvents (_THIS)
     dy = 0;
     
     do {
+        NSAutoreleasePool *pool = [ [ NSAutoreleasePool alloc ] init ];
     
         /* Poll for an event. This will not block */
         event = [ NSApp nextEventMatchingMask:NSAnyEventMask
@@ -1050,13 +1049,12 @@ void QZ_PumpEvents (_THIS)
                     [ NSApp sendEvent:event ];
             }
         }
+        [ pool release ];
     } while (event != nil);
     
     /* handle accumulated mouse moved events */
     if (dx != 0 || dy != 0)
         SDL_PrivateMouseMotion (0, 1, dx, dy);
-    
-    [ pool release ];
 }
 
 void QZ_UpdateMouse (_THIS)


### PR DESCRIPTION
This PR attempts to fix a memory leak that causes macOS Squeezeplay to hang after long execution time.  After running for about 7 to 8 weeks on my machines, Squeezeplay will hang with the spinning beach ball and become unresponsive.  

Running the Instruments app for leak profiling reveals a horror show of NSZombie leaked objects and a steady cadence of red ❌ indicating leaks detected at every snapshot:

<a href="https://github.com/user-attachments/assets/e5879b7f-5251-465f-9a4d-a1e3a2faa2f6">
<img width="300" alt="before" src="https://github.com/user-attachments/assets/e5879b7f-5251-465f-9a4d-a1e3a2faa2f6" />
</a>


After moving the pool creation and release into the inner loop to release the objects more frequently, you see a few leaks at startup, but then the steady cadence of red ❌ is gone.

<a href="https://github.com/user-attachments/assets/158b876e-f950-4887-994b-c6c61ef3e985">
<img width="300" alt="after" src="https://github.com/user-attachments/assets/158b876e-f950-4887-994b-c6c61ef3e985" />
</a>

I would have to run this for more than two months to prove that it fixes the original problem, but even if I'm wrong, the absence of leaks in the "after" profile proves the removal of a memory leak.

Tested (briefly) on:
* macOS 15.5 x86_64
* macOS 15.5 M3
* Mac OS X 10.13.6 x86_64


