### PR TITLE
Add resize parameters to requests for artist artwork

### DIFF
--- a/src/squeezeplay/share/jive/slim/SlimServer.lua
+++ b/src/squeezeplay/share/jive/slim/SlimServer.lua
@@ -1212,6 +1212,9 @@ function fetchArtwork(self, iconId, icon, size, imgFormat)
 			else
 				url = 'http://' .. jnt:getSNHostname() .. '/public/imageproxy?w=' .. sizeW .. '&h=' .. sizeH .. '&f=' .. (imgFormat or '') .. '&u=' .. string.urlEncode(iconId)
 			end
+		-- contributor artwork doesn't come with an extension
+		elseif string.find(iconId, "^contributor/%w+/image") then
+			url = iconId .. resizeFrag
 		else
 			url = string.gsub(iconId, "(.+)(%.%a+)", "%1" .. resizeFrag .. "%2")
 


### PR DESCRIPTION
Squeezeplay currently would always request the full size image - which can be slow to resize on the Radio, or even lead to crashing it if the image is too big to be processed within a reasonable delay.

See https://forums.lyrion.org/forum/user-forums/squeezebox-radio/1803006 for some background.