### PR TITLE
Fix build failures on modern Linux toolchains (GCC 14+/C23, Python 3, x86_64)

### DIFF
--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -259,10 +259,10 @@ squeezeplay/Makefile:
 	cd squeezeplay; SDL_CONFIG=${SDL_CONFIG} ./configure ${ENABLE_SPPRIVATE} ${ENABLE_PROFILING} --prefix=${PREFIX}
 
 squeezeplay: squeezeplay/Makefile
-	patch -p1 -i squeezeplay-lua-cjson.patch
+	patch --forward -p1 -i squeezeplay-lua-cjson.patch || true
 	export PATH=$(BUILD_TOP)/bin:$(PATH); \
 	cd squeezeplay; make && make install
-	patch -p1 -R -i squeezeplay-lua-cjson.patch
+	patch --forward -R -p1 -i squeezeplay-lua-cjson.patch || true
 
 squeezeplay_desktop/Makefile:
 	cd squeezeplay_desktop; SDL_CONFIG=${SDL_CONFIG} ./configure --host=${HOST} --target=${TARGET} --prefix=${PREFIX}

--- a/src/SDL-1.2.15/src/video/Xext/XME/xme.c
+++ b/src/SDL-1.2.15/src/video/Xext/XME/xme.c
@@ -206,7 +206,7 @@ static char *xigmisc_extension_name = XIGMISC_PROTOCOL_NAME;
 /*
  * find_display - locate the display info block
  */
-static int XiGMiscCloseDisplay();
+static int XiGMiscCloseDisplay(Display *dpy, XExtCodes *codes);
 
 static XExtensionHooks xigmisc_extension_hooks = {
     NULL,                               /* create_gc */

--- a/src/SDL-1.2.15/src/video/Xext/Xinerama/Xinerama.c
+++ b/src/SDL-1.2.15/src/video/Xext/Xinerama/Xinerama.c
@@ -50,7 +50,7 @@ static /* const */ char *panoramiX_extension_name = PANORAMIX_PROTOCOL_NAME;
 #define PanoramiXSimpleCheckExtension(dpy,i) \
   XextSimpleCheckExtension (dpy, i, panoramiX_extension_name)
 
-static int close_display();
+static int close_display(Display *dpy, XExtCodes *codes);
 static /* const */ XExtensionHooks panoramiX_extension_hooks = {
     NULL,				/* create_gc */
     NULL,				/* copy_gc */

--- a/src/SDL-1.2.15/src/video/Xext/Xv/Xv.c
+++ b/src/SDL-1.2.15/src/video/Xext/Xv/Xv.c
@@ -63,9 +63,9 @@ static char *xv_extension_name = XvName;
 #define XvCheckExtension(dpy, i, val) \
   XextCheckExtension(dpy, i, xv_extension_name, val)
 
-static char *xv_error_string();
-static int xv_close_display();
-static Bool xv_wire_to_event();
+static char *xv_error_string(Display *dpy, int code, XExtCodes *codes, char *buf, int n);
+static int xv_close_display(Display *dpy, XExtCodes *codes);
+static Bool xv_wire_to_event(Display *dpy, XEvent *host, xEvent *wire);
 
 static XExtensionHooks xv_extension_hooks = {
     NULL,                               /* create_gc */

--- a/src/SDL_gfx-2.0.15/SDL_imageFilter.c
+++ b/src/SDL_gfx-2.0.15/SDL_imageFilter.c
@@ -16,6 +16,11 @@
 
 #include "SDL_imageFilter.h"
 
+/* pusha/popa do not exist in 64-bit mode; disable MMX inline asm there */
+#if defined(__x86_64__) || defined(_M_X64)
+# undef USE_MMX
+#endif
+
 #define swap_32(x) (((x) >> 24) | (((x) & 0x00ff0000) >> 8)  | (((x) & 0x0000ff00) << 8)  | ((x) << 24))
 
 /* ------ Static variables ----- */

--- a/src/libpng-1.2.59/pngrtran.c
+++ b/src/libpng-1.2.59/pngrtran.c
@@ -19,6 +19,7 @@
 #define PNG_INTERNAL
 #define PNG_NO_PEDANTIC_WARNINGS
 #include "png.h"
+#include <math.h>
 #ifdef PNG_READ_SUPPORTED
 
 /* Set the action on getting a CRC error for an ancillary or critical chunk. */

--- a/src/squeezeplay/Makefile.in
+++ b/src/squeezeplay/Makefile.in
@@ -277,9 +277,10 @@ BUNDLE_NAME = SqueezePlay.app
 APP_NAME = SqueezePlay
 BUNDLE_CONTENTS = $(BUNDLE_NAME)/Contents
 PLIST_FILE = $(BUNDLE_CONTENTS)/Info.plist
-VERSION_TEXT = $(shell cat ../squeezeplay.version)r$(shell svnversion -n .. | sed -e 's/[MS]//g')
-DEB_VERSION_TEXT = $(shell cat ../squeezeplay.version)~$(shell svnversion -n .. | sed -e 's/[MS]//g')
-TGZ_VERSION_TEXT = $(shell cat ../squeezeplay.version)-$(shell svnversion -n .. | sed -e 's/[MS]//g')
+VCS_REV := $(shell git -C .. rev-parse --short HEAD 2>/dev/null || echo "unknown")
+VERSION_TEXT = $(shell cat ../squeezeplay.version)r$(VCS_REV)
+DEB_VERSION_TEXT = $(shell cat ../squeezeplay.version)~$(VCS_REV)
+TGZ_VERSION_TEXT = $(shell cat ../squeezeplay.version)-$(VCS_REV)
 ICNS_NAME = icon.icns
 DMG_TEMP_DIR = temp-SqueezePlay_image
 DMG_IMAGE_DIR = SqueezePlay_image
@@ -1349,7 +1350,7 @@ src/version.h: FORCE
 	@echo '#define SQUEEZEPLAY_RELEASE "'`cat ../squeezeplay.version`'"' >> src/version.h
 	@echo '#endif' >> src/version.h
 	@echo '#ifndef SQUEEZEPLAY_REVISION' >> src/version.h
-	@echo '#define SQUEEZEPLAY_REVISION "'`svnversion -n .. | sed -e 's/[MS]//g'`'"' >> src/version.h
+	@echo '#define SQUEEZEPLAY_REVISION "'`git -C .. rev-parse --short HEAD 2>/dev/null || echo "unknown"`'"' >> src/version.h
 	@echo '#endif' >> src/version.h
 	@echo '#define JIVE_VERSION SQUEEZEPLAY_RELEASE" r"SQUEEZEPLAY_REVISION' >> src/version.h
 

--- a/src/squeezeplay/src/types.h
+++ b/src/squeezeplay/src/types.h
@@ -8,9 +8,7 @@
 #define JIVE_TYPES_H
 
 /* boolean type */
-typedef unsigned int bool;
-#define true 1
-#define false !true
+#include <stdbool.h>
 
 /* ip3k type definitions */
 #define bool_t bool

--- a/src/tolua++-1.0.92/SConstruct
+++ b/src/tolua++-1.0.92/SConstruct
@@ -59,8 +59,8 @@ def pkg_scan_dep(self, target, source):
 	## TODO: detectar si el archivo existe antes de abrirlo asi nomas
 	pkg = open(source, "rt")
 
-	for linea in pkg.xreadlines():
-		dep = re.search("^[\t\w]*\$[cphl]file\s*\"([^\"]+)\"", linea)
+	for linea in pkg:
+		dep = re.search(r"^[\t\w]*\$[cphl]file\s*\"([^\"]+)\"", linea)
 		if dep:
 			self.Depends(target, '#' + dep.groups()[0]);
 

--- a/src/tolua++-1.0.92/config_posix.py
+++ b/src/tolua++-1.0.92/config_posix.py
@@ -16,7 +16,7 @@ CCFLAGS = ['-O2', '-ansi', '-Wall']
 prefix = '/usr/local'
 
 # libraries
-LIBS = ['lua', 'lualib', 'm']
+LIBS = ['lua', 'm']
 
 
 


### PR DESCRIPTION
## Summary

This PR fixes several build failures that occur when building SqueezePlay on modern Linux systems (GCC 14+, Python 3, x86_64).

### C source compatibility (GCC 14+ / C23)

- **`SDL-1.2.15/src/video/Xext/Xv/Xv.c`**: Replace empty `()` forward declarations with proper prototypes matching the `XEXT_GENERATE_*` macro signatures. C23 treats `()` as `(void)`, causing signature mismatches.
- **`SDL-1.2.15/src/video/Xext/Xinerama/Xinerama.c`**: Same fix for `close_display()`.
- **`SDL-1.2.15/src/video/Xext/XME/xme.c`**: Same fix for `XiGMiscCloseDisplay()`.
- **`libpng-1.2.59/pngrtran.c`**: Add missing `#include <math.h>` to fix implicit declaration of `fabs`/`pow`.
- **`squeezeplay/src/types.h`**: Replace `typedef unsigned int bool` with `#include <stdbool.h>`. In C23, `bool` is a keyword and cannot be typedef'd.

### x86_64 compatibility (SDL_gfx)

- **`SDL_gfx-2.0.15/SDL_imageFilter.c`**: Guard `USE_MMX` with an `#if defined(__x86_64__)` check. The `pusha`/`popa` instructions used in the MMX inline assembly do not exist in 64-bit mode.

### Python 3 compatibility (tolua++)

- **`tolua++-1.0.92/SConstruct`**: Replace removed `xreadlines()` with direct iteration, and fix `DeprecationWarning`-turned-error by using a raw string for the regex pattern.
- **`tolua++-1.0.92/config_posix.py`**: Remove `-llualib` from the link libraries. Since Lua 5.1, `lualib` has been merged into `liblua` and no longer exists as a separate library.

### Build system

- **`Makefile.linux`**: Make the `squeezeplay-lua-cjson.patch` apply/reverse idempotent using `patch --forward ... || true`, so repeated or incremental builds don't fail.
- **`squeezeplay/Makefile.in`**: Replace `svnversion` with `git rev-parse --short HEAD` for generating the build revision. `svnversion` returns `"Unversioned directory"` (with spaces, breaking Makefile variable expansion) on non-SVN checkouts.