### PR TITLE
use SDL_PollEvent() to pump macOS events at startup

### DIFF
--- a/src/squeezeplay/src/ui/jive_framework.c
+++ b/src/squeezeplay/src/ui/jive_framework.c
@@ -329,7 +329,8 @@ static int jiveL_initSDL(lua_State *L) {
 		jive_surface_flip(srf);
 		LOG_INFO(log_ui_draw, "Splash %s %dx%d Screen %dx%d", splashfile,splash_w,splash_h,screen_w,screen_h);
 #if defined(__APPLE__) && defined(__MACH__)
-		SDL_PumpEvents(); // pump event queue to update screen
+		SDL_Event evt;
+		while (SDL_PollEvent(&evt)) {} // pump event queue to update screen
 #endif
 	}
 


### PR DESCRIPTION
On my Tahoe 26.5.1 system SqueezePlay will fail to render its initial screen a significant percentage of the time at application startup.  The symptom is a blank rectangle that remains until you resize the window.  This issue has been [observed](https://github.com/libsdl-org/SDL/issues/13920) in the SDL2 project.  This PR uses the [workaround](https://github.com/libsdl-org/SDL/issues/13920#issuecomment-3516980770) mentioned in that thread to pump all the pending events so that the initial screen is rendered properly.

Tested on:
* macOS 15.7.7 (24G720) | Xcode 26.3.0.0.1.1771626560 | Clang 17.0.0 | Intel
* macOS 26.5.1 (25F80) | Xcode 26.5.0.0.1777544298 | Clang 21.0.0 | Apple Silicon
